### PR TITLE
Remove ocaml build dependency from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --update build-base curl bash && \
     make && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
     # Remove build tools
-    apk del build-base curl emacs && \
+    apk del build-base curl emacs ocaml && \
     # Remove tmp files and caches
     rm -rf /var/cache/apk/* && \
     rm -rf /tmp/unison-${UNISON_VERSION}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Docker-Unison
 A docker volume container using [Unison](http://www.cis.upenn.edu/~bcpierce/unison/) for fast two-way folder sync. Created as an alternative to [slow docker for mac volumes on OS X](https://forums.docker.com/t/file-access-in-mounted-volumes-extremely-slow-cpu-bound/8076).
 
+This image is trying to be as minimal as possible and it only weights `14.41MB`.
+
 The docker image is available on Docker Hub:
 [registry.hub.docker.com/u/onnimonni/unison/](https://registry.hub.docker.com/u/onnimonni/unison/)
 


### PR DESCRIPTION
unison binaries don't need those and this way the image can then be smaller.