### PR TITLE
Remove ocaml from the docker image after building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --update build-base curl bash && \
     make && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
     # Remove build tools
-    apk del build-base curl emacs && \
+    apk del build-base curl emacs ocaml && \
     # Remove tmp files and caches
     rm -rf /var/cache/apk/* && \
     rm -rf /tmp/unison-${UNISON_VERSION}


### PR DESCRIPTION
Unison binaries don't need those and this way the image can then be smaller.
After this the image drops from 196.3MB -> 14.41MB