### PR TITLE
Unison with fsevents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,22 @@ FROM alpine:edge
 MAINTAINER Eugen Mayer <eugen.mayer@kontextwork.com>
 
 ARG UNISON_VERSION=2.48.4
+ARG FSWATCH_VERSION=1.9.2
 
-# Install in one run so that build tools won't remain in any docker layers
-# Install build tools
 RUN apk add --update build-base curl bash && \
-    # Install ocaml & emacs from testing repositories
     apk add --update-cache --repository http://dl-4.alpinelinux.org/alpine/edge/testing/ ocaml emacs && \
-    # Download & Install Unison
     curl -L https://github.com/bcpierce00/unison/archive/$UNISON_VERSION.tar.gz | tar zxv -C /tmp && \
     cd /tmp/unison-${UNISON_VERSION} && \
     sed -i -e 's/GLIBC_SUPPORT_INOTIFY 0/GLIBC_SUPPORT_INOTIFY 1/' src/fsmonitor/linux/inotify_stubs.c && \
     make && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
-    # Remove build tools
-    apk del build-base curl emacs ocaml && \
-    # Remove tmp files and caches
+    curl -L https://github.com/emcrisostomo/fswatch/releases/download/${FSWATCH_VERSION}/fswatch-${FSWATCH_VERSION}.tar.gz | tar zxv -C /tmp && \
+    cd /tmp/fswatch-${FSWATCH_VERSION} && \
+    ./configure && make && make install && \
+    apk del curl emacs && \
     rm -rf /var/cache/apk/* && \
-    rm -rf /tmp/unison-${UNISON_VERSION}
+    rm -rf /tmp/unison-${UNISON_VERSION} && \
+    rm -rf /tmp/fswatch-${FSWATCH_VERSION}
 
 # These can be overridden later
 ENV TZ="Europe/Helsinki" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,20 +28,18 @@ ENV TZ="Europe/Helsinki" \
     UNISON_DIR="/data" \
     HOME="/root"
 
-# Install unison server script
-RUN mkdir -p /docker-entrypoint.d
-ADD entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ADD unison.sh /unison.sh
-RUN chmod +x /unison.sh
-ADD fswatch.sh /fswatch.sh
-RUN chmod +x /fswatch.sh
-
-RUN mkdir -p /etc/supervisor/conf.d
-
+COPY unison.sh /unison.sh
+COPY fswatch.sh /fswatch.sh
+COPY entrypoint.sh /entrypoint.sh
 COPY supervisord.conf /etc/supervisord.conf
 COPY supervisor.fswatch.conf /etc/supervisor/conf.d/supervisor.fswatch.conf
 COPY supervisor.unison.conf /etc/supervisor/conf.d/supervisor.unison.conf
+
+RUN mkdir -p /docker-entrypoint.d \
+ && chmod +x /entrypoint.sh \
+ && chmod +x /unison.sh \
+ && chmod +x /fswatch.sh \
+ && mkdir -p /etc/supervisor/conf.d
 
 EXPOSE 5000
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN apk add --update build-base curl bash supervisor && \
     cp src/unison src/unison-fsmonitor /usr/local/bin && \
     curl -L https://github.com/emcrisostomo/fswatch/releases/download/${FSWATCH_VERSION}/fswatch-${FSWATCH_VERSION}.tar.gz | tar zxv -C /tmp && \
     cd /tmp/fswatch-${FSWATCH_VERSION} && \
-    ./configure && make && make install && \
-    apk del curl emacs && \
+    ./configure && make && make install && make clean && make distclean && \
+    apk del curl emacs build-base ocaml && \
+    apk --update add libgcc libstdc++ && \
     rm -rf /var/cache/apk/* && \
     rm -rf /tmp/unison-${UNISON_VERSION} && \
     rm -rf /tmp/fswatch-${FSWATCH_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Eugen Mayer <eugen.mayer@kontextwork.com>
 ARG UNISON_VERSION=2.48.4
 ARG FSWATCH_VERSION=1.9.2
 
-RUN apk add --update build-base curl bash && \
+RUN apk add --update build-base curl bash supervisor && \
     apk add --update-cache --repository http://dl-4.alpinelinux.org/alpine/edge/testing/ ocaml emacs && \
     curl -L https://github.com/bcpierce00/unison/archive/$UNISON_VERSION.tar.gz | tar zxv -C /tmp && \
     cd /tmp/unison-${UNISON_VERSION} && \
@@ -28,7 +28,19 @@ ENV TZ="Europe/Helsinki" \
     HOME="/root"
 
 # Install unison server script
-COPY entrypoint.sh /entrypoint.sh
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ADD unison-start.sh /unison-start.sh
+RUN chmod +x /unison-start.sh
+ADD fswatch.sh /fswatch.sh
+RUN chmod +x /fswatch.sh
+
+RUN mkdir -p /etc/supervisor/conf.d
+
+COPY supervisord.conf /etc/supervisord.conf
+COPY supervisor.fswatch.conf /etc/supervisor/conf.d/supervisor.fswatch.conf
+COPY supervisor.unison.conf /etc/supervisor/conf.d/supervisor.unison.conf
 
 EXPOSE 5000
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ ENV TZ="Europe/Helsinki" \
 # Install unison server script
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ADD unison-start.sh /unison-start.sh
-RUN chmod +x /unison-start.sh
+ADD unison.sh /unison.sh
+RUN chmod +x /unison.sh
 ADD fswatch.sh /fswatch.sh
 RUN chmod +x /fswatch.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:edge
 # This is the real maintainer
 # MAINTAINER Onni Hakala <onni.hakala@geniem.com>
+# MAINTAINER Mickaël Perrin <dev@mickaelperrin.fr>
 MAINTAINER Eugen Mayer <eugen.mayer@kontextwork.com>
 
 ARG UNISON_VERSION=2.48.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV TZ="Europe/Helsinki" \
     HOME="/root"
 
 # Install unison server script
+RUN mkdir -p /docker-entrypoint.d
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ADD unison.sh /unison.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,8 @@ if [ "$1" == 'supervisor' ]; then
       mv /etc/supervisor/conf.d/supervisor.fswatch.conf /etc/supervisor/conf.d/supervisor.fswatch.conf.deactivated
     fi
 
-    # Check if a script is available in /lsyncd-entrypoint.d and source it
-    for f in /lsyncd-entrypoint.d/*; do
+    # Check if a script is available in /docker-entrypoint.d and source it
+    for f in /docker-entrypoint.d/*; do
         case "$f" in
             *.sh)     echo "$0: running $f"; . "$f" ;;
             *)        echo "$0: ignoring $f" ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,23 +1,20 @@
 #!/usr/bin/env bash
+set -e
 
-# Create directory for filesync
-if [ ! -d "$UNISON_DIR" ]; then
-    echo "Creating $UNISON_DIR directory for sync..."
-    mkdir -p $UNISON_DIR >> /dev/null 2>&1
+if [ "$1" == 'supervisor' ]; then
+
+    # Deactivate fswatch if needed
+    if [ -z $ENABLE_WATCH ]; then
+      mv /etc/supervisor/conf.d/supervisor.fswatch.conf /etc/supervisor/conf.d/supervisor.fswatch.conf.deactivated
+    fi
+
+    # Check if a script is available in /lsyncd-entrypoint.d and source it
+    for f in /lsyncd-entrypoint.d/*; do
+        case "$f" in
+            *.sh)     echo "$0: running $f"; . "$f" ;;
+            *)        echo "$0: ignoring $f" ;;
+        esac
+    done
 fi
 
-# Start process on path which we want to sync
-cd $UNISON_DIR
-
-# Gracefully stop the process on 'docker stop'
-trap 'kill -TERM $PID' TERM INT
-
-# Run unison server
-unison -socket 5000 &
-
-# Wait until the process is stopped
-PID=$!
-wait $PID
-trap - TERM INT
-wait $PID
-EXIT_STATUS=$?
+exec "$@"

--- a/fswatch.sh
+++ b/fswatch.sh
@@ -2,6 +2,6 @@
 set -e
 cd $UNISON_DIR
 [ ! -z $UNISON_DIR_OWNER ] && UNISON_MANAGE_OWNER="-owner -numericids" || UNISON_MANAGE_OWNER=""
-cmd="fswatch ${FSWATCH_EXCLUDES} -orIE ${UNISON_DIR} | xargs -I -n1 unison $UNISON_EXCLUDES \"$UNISON_DIR\" -auto -batch $UNISON_MANAGE_OWNER socket://${HOST_IP}:${UNISON_HOST_PORT}"
+cmd="fswatch ${FSWATCH_EXCLUDES} -orIE --event Updated --event Removed --event AttributeModified --event Created --event Link --event MovedFrom --event MovedTo --event Renamed ${UNISON_DIR} | xargs -I -n1 unison $UNISON_EXCLUDES \"$UNISON_DIR\" -auto -batch $UNISON_MANAGE_OWNER socket://${HOST_IP}:${UNISON_HOST_PORT}"
 echo $cmd
 eval $cmd

--- a/fswatch.sh
+++ b/fswatch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+cd $UNISON_DIR
+cmd="fswatch ${FSWATCH_EXCLUDES} -orIE ${UNISON_DIR} | xargs -I -n1 unison $UNISON_EXCLUDES \"$UNISON_DIR\" -auto -batch -owner -numericids socket://${HOST_IP}:${UNISON_HOST_PORT}"
+echo $cmd
+eval $cmd

--- a/fswatch.sh
+++ b/fswatch.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 cd $UNISON_DIR
-cmd="fswatch ${FSWATCH_EXCLUDES} -orIE ${UNISON_DIR} | xargs -I -n1 unison $UNISON_EXCLUDES \"$UNISON_DIR\" -auto -batch -owner -numericids socket://${HOST_IP}:${UNISON_HOST_PORT}"
+[ ! -z $UNISON_DIR_OWNER ] && UNISON_MANAGE_OWNER="-owner -numericids" || UNISON_MANAGE_OWNER=""
+cmd="fswatch ${FSWATCH_EXCLUDES} -orIE ${UNISON_DIR} | xargs -I -n1 unison $UNISON_EXCLUDES \"$UNISON_DIR\" -auto -batch $UNISON_MANAGE_OWNER socket://${HOST_IP}:${UNISON_HOST_PORT}"
 echo $cmd
 eval $cmd

--- a/supervisor.fswatch.conf
+++ b/supervisor.fswatch.conf
@@ -1,0 +1,4 @@
+[program:fswatch]
+command=/fswatch.sh
+user=root
+redirect_stderr=true

--- a/supervisor.unison.conf
+++ b/supervisor.unison.conf
@@ -1,0 +1,4 @@
+[program:unison]
+command=/unison.sh
+user=root
+redirect_stderr=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,17 @@
+[supervisord]
+logfile=/tmp/supervisord.log
+loglevel=info
+pidfile=/tmp/supervisord.pid
+nodaemon=true
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[include]
+files=/etc/supervisor/conf.d/*.conf

--- a/unison.sh
+++ b/unison.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Start process on path which we want to sync
+[ ! -d $UNISON_DIR ] && mkdir -p $UNISON_DIR >> /dev/null 2>&1
+[ ! -z $UNISON_DIR_OWNER ] && chown $UNISON_DIR_OWNER $UNISON_DIR >> /dev/null 2>&1
+cd $UNISON_DIR
+
+# Gracefully stop the process on 'docker stop'
+trap 'kill -TERM $PID' TERM INT
+
+# Run unison server
+unison -socket 5000 &
+
+# Wait until the process is stopped
+PID=$!
+wait $PID
+trap - TERM INT
+wait $PID


### PR DESCRIPTION
This PR adds support (optionnal) for `fsevents` on the container side.

Fsevents is compiled from source (note that build-base is not deleted, because fsevents needs some library event after compilation).

Fsevents and unison are managed with supervisor.

Entrypoint has been rewritten and supports additionnal start-up scripts and easy "ssh" into the container with `docker exec -it container_name bash`.

Configuration is done mainly through additional env variables.

